### PR TITLE
Allow empty query results

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -12,9 +12,11 @@ formatSolveBioResponse <- function (res, raw = FALSE) {
 
 formatSolveBioQueryResponse <- function (res, raw = FALSE) {
     # res will be the output of formatSolveBioResponse
-    if (!raw) {
+    if (!raw & is.data.frame(res$results)) {
         # Flatten the data frame
         res$results <- jsonlite::flatten(res$results)
+    } else {
+      res$results <- as.data.frame(res$results)
     }
     return(res)
 }


### PR DESCRIPTION
When query results are empty, res$results contains an
empty list, which causes jsonlite::flatten to throw an
exception. Instead, convert to an empty data.frame for
consistency with nonempty query results.