### PR TITLE
plyr rbind.fill

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,7 +13,8 @@ Description: R language bindings for SolveBio's API.
 URL: https://github.com/solvebio/solvebio-r
 Imports:
     httr,
-    jsonlite
+    jsonlite,
+    dplyr (>= 0.5.0)
 License: MIT + file LICENSE
 Collate:
     solvebio.R

--- a/R/dataset.R
+++ b/R/dataset.R
@@ -118,8 +118,7 @@ Dataset.query <- function(id, paginate=FALSE, ...) {
         params['offset'] <- offset
         response <- do.call(Dataset.data, c(id=id, params))
         df_page <- response$results
-        df <- plyr::rbind.fill(df, df_page)
-        # df <- rbind(df, df_page)
+        df <- dplyr::bind_rows(df, df_page)
         offset <- response$offset
 
         # only fetch max_records

--- a/R/dataset.R
+++ b/R/dataset.R
@@ -118,7 +118,8 @@ Dataset.query <- function(id, paginate=FALSE, ...) {
         params['offset'] <- offset
         response <- do.call(Dataset.data, c(id=id, params))
         df_page <- response$results
-        df <- rbind(df, df_page)
+        df <- plyr::rbind.fill(df, df_page)
+        # df <- rbind(df, df_page)
         offset <- response$offset
 
         # only fetch max_records


### PR DESCRIPTION
this uses a different bind (rbind.fill from plyr package) function when performing paginating queries that attach new rows to a growing data frame. this fixes the problem for cases where records from the same dataset may have different field sets. 