### PR TITLE
add 'stop' for no response

### DIFF
--- a/R/dataset.R
+++ b/R/dataset.R
@@ -288,7 +288,7 @@ Dataset.get_by_full_path <- function(full_path) {
     object = Object.get_by_full_path(full_path)
 
     if (is.null(object)) {
-        return(NULL)
+        stop(sprintf("Error: No object found with full path: %s\n", full_path))
     }
 
     # TODO: This raises an exception on 404, should we return NULL?

--- a/R/dataset.R
+++ b/R/dataset.R
@@ -287,11 +287,6 @@ Dataset.create <- function(vault_id, vault_parent_object_id, name, ...) {
 Dataset.get_by_full_path <- function(full_path) {
     object = Object.get_by_full_path(full_path)
 
-    if (is.null(object)) {
-        stop(sprintf("Error: No object found with full path: %s\n", full_path))
-    }
-
-    # TODO: This raises an exception on 404, should we return NULL?
     dataset = do.call(Dataset.retrieve, list(id=object$dataset_id))
     return(dataset)
 }

--- a/R/object.R
+++ b/R/object.R
@@ -149,7 +149,8 @@ Object.get_by_full_path <- function(full_path, ...) {
     response <- .request('GET', path='v2/objects', query=params)
 
     if (response$total == 0) {
-        stop(sprintf("Error: No object found with full path: %s\n", full_path))
+        # stop(sprintf("Error: No object found with full path: %s\n", full_path))
+        return(NULL)
     }
     if (response$total > 1) {
         cat(sprintf("Warning: Multiple object found with full path: %s\n", full_path))

--- a/R/object.R
+++ b/R/object.R
@@ -149,8 +149,7 @@ Object.get_by_full_path <- function(full_path, ...) {
     response <- .request('GET', path='v2/objects', query=params)
 
     if (response$total == 0) {
-        # stop(sprintf("Error: No object found with full path: %s\n", full_path))
-        return(NULL)
+        stop(sprintf("Error: No object found with full path: %s\n", full_path))
     }
     if (response$total > 1) {
         cat(sprintf("Warning: Multiple object found with full path: %s\n", full_path))

--- a/R/object.R
+++ b/R/object.R
@@ -149,7 +149,7 @@ Object.get_by_full_path <- function(full_path, ...) {
     response <- .request('GET', path='v2/objects', query=params)
 
     if (response$total == 0) {
-        return(NULL)
+        stop(sprintf("Error: No object found with full path: %s\n", full_path))
     }
     if (response$total > 1) {
         cat(sprintf("Warning: Multiple object found with full path: %s\n", full_path))


### PR DESCRIPTION
When an invalid Vault path is provided, `NULL` is returned. This results in silent errors which later break scripts depending on API output. Added `stop()` in `Dataset.get_by_full_path` and `Object.get_by_full_path` to raise an error when this occurs.

Example code:
```
library(solvebio)
login()
# Invalid, but returns NULL
Dataset.get_by_full_path("solveBio:public:/3DHotSpots/1.0.0-2017-01/SignificantResidues")

# valid
Dataset.get_by_full_path("solveBio:public:/3DHotSpots/1.0.0-2017-01/SignificantResidues-GRCh37")

```