### PR TITLE
Simplify secure storing of client secret

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -42,5 +42,4 @@ Suggests:
     testthat,
     shiny,
     shinyjs,
-    PKI,
-    digest
+    openssl


### PR DESCRIPTION
This drops the dependency on the PKI package, which has not been updated for a long time and has some serious [installation issues](http://bit.ly/2rOAfqJ). While editing I also tried to simplify the code a bit.

I am not sure how how to test this package (I don't use shiny much) but if I understand correctly what you're trying to do here (make the token persistent between sessions), then I think using base64 and openssl is much easier then manually editing the strings and raw vectors.
