### PR TITLE
Always use the global API host by default

### DIFF
--- a/R/shiny.R
+++ b/R/shiny.R
@@ -184,6 +184,7 @@ protectedServer <- function(server, client_id, client_secret=NULL, base_url="htt
                                                  path="v1/oauth2/token",
                                                  query=NULL,
                                                  body=oauth_params,
+                                                 env=solvebio::createEnv(),
                                                  content_type="application/x-www-form-urlencoded")
                                     }, error = function(e) {
                                         stop("ERROR: Unable to retrieve SolveBio OAuth2 token. Check your client_id and client_secret (if used).")

--- a/R/solvebio.R
+++ b/R/solvebio.R
@@ -75,7 +75,7 @@ login <- function(api_key, api_host, env = solvebio:::.solveEnv) {
 #' \url{https://docs.solvebio.com/}
 #'
 #' @export
-createEnv <- function(token, token_type="Token", host="https://api.solvebio.com") {
+createEnv <- function(token, token_type="Token", host=.solveEnv$host) {
     newEnv <- new.env()
     newEnv$token <- token
     newEnv$token_type <- token_type

--- a/man/createEnv.Rd
+++ b/man/createEnv.Rd
@@ -4,7 +4,7 @@
 \alias{createEnv}
 \title{createEnv}
 \usage{
-createEnv(token, token_type = "Token", host = "https://api.solvebio.com")
+createEnv(token, token_type = "Token", host = .solveEnv$host)
 }
 \arguments{
 \item{token}{A SolveBio API key or OAuth2 token}


### PR DESCRIPTION
This allows Shiny apps to just set the SOLVEBIO_API_HOST environment variable