### PR TITLE
Fix issue with paginating results containing different data types for the same field

### DIFF
--- a/R/dataset.R
+++ b/R/dataset.R
@@ -180,8 +180,7 @@ Dataset.query <- function(id, paginate=FALSE, use_field_titles=TRUE, env = solve
     while (isTRUE(paginate) && !is.null(offset)) {
         params$offset <- offset
         response <- do.call(Dataset.data, params)
-        df_page <- response$results
-        df <- dplyr::bind_rows(df, df_page)
+        df <- jsonlite::rbind_pages(list(df, response$results))
         offset <- response$offset
     }
 

--- a/R/global_search.R
+++ b/R/global_search.R
@@ -42,8 +42,8 @@ GlobalSearch.search <- function(paginate=FALSE, env = solvebio:::.solveEnv, ...)
   while (isTRUE(paginate) && !is.null(offset)) {
     params$offset <- offset
     response <- do.call(GlobalSearch.request, params)
-    df_page <- response$results
-    df <- dplyr::bind_rows(df, df_page)
+    # df <- dplyr::bind_rows(df, df_page)
+    df <- jsonlite::rbind_pages(list(df, response$results))
     offset <- response$offset
   }
 
@@ -51,7 +51,6 @@ GlobalSearch.search <- function(paginate=FALSE, env = solvebio:::.solveEnv, ...)
     warning(paste("This call returned only the first page of records. To retrieve more pages automatically,",
                   "please set paginate=TRUE when calling GlobalSearch.search().", call. = FALSE))
   }
-
 
   return(df)
 }

--- a/R/object.R
+++ b/R/object.R
@@ -466,8 +466,7 @@ Object.query <- function(id, paginate=FALSE, env = solvebio:::.solveEnv, ...) {
     while (isTRUE(paginate) && !is.null(offset)) {
         params$offset <- offset
         response <- do.call(Object.data, params)
-        df_page <- response$results
-        df <- dplyr::bind_rows(df, df_page)
+        df <- jsonlite::rbind_pages(list(df, response$results))
         offset <- response$offset
     }
 


### PR DESCRIPTION
use jsonlite rbind_pages instead of dplyr bind_rows to fix issues with combining pages of results with different data types
closes #123